### PR TITLE
Add a close button to the results

### DIFF
--- a/Support/document.js
+++ b/Support/document.js
@@ -13,6 +13,11 @@ Zepto(document).ready(function($) {
       }
     }, 1);
   });
+  //Close the report window when clickie on close 'x'
+  $('#close').on('click',function () {
+    //Close the report window when clickie on close 'x'
+    TextMate.system('osascript -e \'tell application "System Events" to keystroke "h" using {command down, control down, option down}\'',function(){/*console.log('done')*/});
+  });
 
   // close the report window when the user presses ESCape
   $(document).keydown(function(e) {

--- a/Support/template.html
+++ b/Support/template.html
@@ -23,6 +23,7 @@
     </style>
 </head>
 <body>
+    <span class="button" id="close">&times;</span>
     <div id="content">
         <!-- EJS-rendered content goes here -->
     </div>


### PR DESCRIPTION
As a new user, I was concerned about having to close the window with `control + option + command + H` being too much. So I wrote this before realising the escape key did the same thing.

Thought I'd make a pull request incase others felt it missing as well.
